### PR TITLE
toprettyxml replacement for Python 2.6 compatibility

### DIFF
--- a/samifmod.py
+++ b/samifmod.py
@@ -164,7 +164,7 @@ class SamConnection:
                   '</security><requestID>PythonClient:' + str(requestId) + \
                   '</requestID></header></SOAP:Header><SOAP:Body>' + \
                   xmlapi + '</SOAP:Body></SOAP:Envelope>'
-        return xml.dom.minidom.parseString(request).toprettyxml()
+        return xml.dom.minidom.parseString(request).toxml()
 
     @staticmethod
     def isActive(samserver="http://SamOClient:5620Sam!@172.23.81.20"):


### PR DESCRIPTION
The toprettyxml method of a DOM object has different behavior depending on the Python version.
In 2.6 it inserts undesired line breaks that cause the authentication to fail:

```
<?xml version="1.0" ?>
<SOAP:Envelope xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/">
	<SOAP:Header>
		<header xmlns="xmlapi_1.0">
			<security>
				<user>
					username
				</user>
				<password>
					cda114ba3be93d2d0262084509aece98
				</password>
			</security>
			<requestID>
				PythonClient:-1
			</requestID>
		</header>
	</SOAP:Header>
	<SOAP:Body>
		<ping xmlns="xmlapi_1.0"/>
	</SOAP:Body>
</SOAP:Envelope>
```

```
18/11/23 17:43:53,780 WARNING  MainThread bad response:	[security] Login failure.
18/11/23 17:43:53,781 ERROR    MainThread Exception SOAPError: SOAPError: [security] Login failure.
5620SAM Server is NOT reachable
```


In 2.7 these line breaks are not inserted, so the authentication does not fail:

```
<?xml version="1.0" ?>
<SOAP:Envelope xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/">
	<SOAP:Header>
		<header xmlns="xmlapi_1.0">
			<security>
				<user>username</user>
				<password>cda114ba3be93d2d0262084509aece98</password>
			</security>
			<requestID>PythonClient:-1</requestID>
		</header>
	</SOAP:Header>
	<SOAP:Body>
		<ping xmlns="xmlapi_1.0"/>
	</SOAP:Body>
</SOAP:Envelope>
```

```
18/11/23 17:45:00,446 INFO     MainThread connect to 122.34.2.18:8080
18/11/23 17:45:00,549 INFO     MainThread http reply received from 122.34.2.18
<?xml version="1.0" ?>
<SOAP:Envelope xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/">
	<SOAP:Header>
		<header xmlns="xmlapi_1.0">
			<requestID>PythonClient:-1</requestID>
			<requestTime>Nov 23, 2018 5:45:00 PM</requestTime>
			<responseTime>Nov 23, 2018 5:45:00 PM</responseTime>
		</header>
	</SOAP:Header>
	<SOAP:Body>
		<versionResponse xmlns="xmlapi_1.0">
			<version>5620 SAM Version 14.0.R7.0</version>
			<baseVersion>14.0</baseVersion>
			<build>R7</build>
			<patch>16</patch>
		</versionResponse>
	</SOAP:Body>
</SOAP:Envelope>


14.0.R7-16
```

By replacing it with toxml(), no line breaks are involved at all, and despite affecting the debug output readability, it works for both versions.